### PR TITLE
Webrtc signaling server + room param

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
-
 ## Getting Started
 
 First, run the development server:
@@ -12,23 +10,12 @@ yarn dev
 pnpm dev
 ```
 
+Then, run the signaling server (port 4444 by default, use PORT= env varto change):
+
+```bash
+node bin/server.js
+```
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+TODO: Add note for running the signaling server.

--- a/app/store.ts
+++ b/app/store.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { syncedStore, getYjsDoc } from '@syncedstore/core'
 import { WebrtcProvider } from 'y-webrtc'
 
@@ -21,7 +23,13 @@ export const store = syncedStore<{
 
 // Create a document that syncs automatically using Y-WebRTC
 const doc = getYjsDoc(store)
-export const webrtcProvider = new WebrtcProvider('syncedstore-playlist', doc)
+
+const roomName =
+  new URLSearchParams(window.location.search).get('room') || 'default-room'
+
+export const webrtcProvider = new WebrtcProvider(roomName, doc, {
+  signaling: ['ws://localhost:4444'],
+})
 
 export const disconnect = () => webrtcProvider.disconnect()
 export const connect = () => webrtcProvider.connect()

--- a/bin/server.js
+++ b/bin/server.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+
+import { WebSocketServer } from 'ws'
+import http from 'http'
+import * as map from 'lib0/map'
+
+const wsReadyStateConnecting = 0
+const wsReadyStateOpen = 1
+const wsReadyStateClosing = 2 // eslint-disable-line
+const wsReadyStateClosed = 3 // eslint-disable-line
+
+const pingTimeout = 30000
+
+const port = process.env.PORT || 4444
+const wss = new WebSocketServer({ noServer: true })
+
+const server = http.createServer((request, response) => {
+  response.writeHead(200, { 'Content-Type': 'text/plain' })
+  response.end('okay')
+})
+
+/**
+ * Map froms topic-name to set of subscribed clients.
+ * @type {Map<string, Set<any>>}
+ */
+const topics = new Map()
+
+/**
+ * @param {any} conn
+ * @param {object} message
+ */
+const send = (conn, message) => {
+  if (conn.readyState !== wsReadyStateConnecting && conn.readyState !== wsReadyStateOpen) {
+    conn.close()
+  }
+  try {
+    conn.send(JSON.stringify(message))
+  } catch (e) {
+    conn.close()
+  }
+}
+
+/**
+ * Setup a new client
+ * @param {any} conn
+ */
+const onconnection = conn => {
+  /**
+   * @type {Set<string>}
+   */
+  const subscribedTopics = new Set()
+  let closed = false
+  // Check if connection is still alive
+  let pongReceived = true
+  const pingInterval = setInterval(() => {
+    if (!pongReceived) {
+      conn.close()
+      clearInterval(pingInterval)
+    } else {
+      pongReceived = false
+      try {
+        conn.ping()
+      } catch (e) {
+        conn.close()
+      }
+    }
+  }, pingTimeout)
+  conn.on('pong', () => {
+    pongReceived = true
+  })
+  conn.on('close', () => {
+    subscribedTopics.forEach(topicName => {
+      const subs = topics.get(topicName) || new Set()
+      subs.delete(conn)
+      if (subs.size === 0) {
+        topics.delete(topicName)
+      }
+    })
+    subscribedTopics.clear()
+    closed = true
+  })
+  conn.on('message', /** @param {object} message */ message => {
+    if (typeof message === 'string' || message instanceof Buffer) {
+      message = JSON.parse(message)
+    }
+    if (message && message.type && !closed) {
+      switch (message.type) {
+        case 'subscribe':
+          /** @type {Array<string>} */ (message.topics || []).forEach(topicName => {
+            if (typeof topicName === 'string') {
+              // add conn to topic
+              const topic = map.setIfUndefined(topics, topicName, () => new Set())
+              topic.add(conn)
+              // add topic to conn
+              subscribedTopics.add(topicName)
+            }
+          })
+          break
+        case 'unsubscribe':
+          /** @type {Array<string>} */ (message.topics || []).forEach(topicName => {
+            const subs = topics.get(topicName)
+            if (subs) {
+              subs.delete(conn)
+            }
+          })
+          break
+        case 'publish':
+          if (message.topic) {
+            const receivers = topics.get(message.topic)
+            if (receivers) {
+              message.clients = receivers.size
+              receivers.forEach(receiver =>
+                send(receiver, message)
+              )
+            }
+          }
+          break
+        case 'ping':
+          send(conn, { type: 'pong' })
+      }
+    }
+  })
+}
+wss.on('connection', onconnection)
+
+server.on('upgrade', (request, socket, head) => {
+  // You may check auth of request here..
+  /**
+   * @param {any} ws
+   */
+  const handleAuth = ws => {
+    wss.emit('connection', ws, request)
+  }
+  wss.handleUpgrade(request, socket, head, handleAuth)
+})
+
+server.listen(port)
+
+console.log('Signaling server running on localhost:', port)


### PR DESCRIPTION
Add example signaling server from y-webrtc (https://github.com/yjs/y-webrtc, revision https://github.com/yjs/y-webrtc/commit/61676a8187e7bd545fd12d0ad6d85f9299b9c0ac) and use it for the WebrtcProvider / SyncedStore.

Also, add a 'room' query param that changes the room key used for WebrtcProvider, segmenting clients into different groups. For instance, if you load up URL `http://localhost:3000/?room=blarg`, you will be in room 'blarg', and share state with all users in that room, but not in other rooms.