### PR TITLE
Creating a new room on load, loading an existing room, and URL copy button

### DIFF
--- a/app/components/MediaContainer.tsx
+++ b/app/components/MediaContainer.tsx
@@ -4,9 +4,13 @@ import React from 'react'
 import { useSyncedStore } from '@syncedstore/react'
 
 import MediaPlayer from '@/app/components/MediaPlayer'
-import { store } from '@/app/store'
+import { Store } from '@/app/store'
 
-const MediaContainer = () => {
+type Props = {
+  store: Store
+}
+
+const MediaContainer = ({ store }: Props) => {
   const state = useSyncedStore(store)
 
   return (

--- a/app/components/Playlist.tsx
+++ b/app/components/Playlist.tsx
@@ -2,10 +2,16 @@
 
 import React from 'react'
 import { Button, Heading, Section, TextInput, Tile } from '@carbon/react'
-import { Edit, Delete, SkipForwardFilled } from '@carbon/icons-react'
+import {
+  Checkmark,
+  Copy,
+  Delete,
+  Edit,
+  SkipForwardFilled,
+} from '@carbon/icons-react'
 import { useSyncedStore } from '@syncedstore/react'
 
-import { store, PlaylistEntry } from '@/app/store'
+import { Store, PlaylistEntry } from '@/app/store'
 
 import styles from './Playlist.module.sass'
 
@@ -85,8 +91,22 @@ const PlaylistEntryRow = ({
   )
 }
 
-const Playlist = () => {
+type Props = {
+  store: Store
+}
+
+const Playlist = ({ store }: Props) => {
   const state = useSyncedStore(store)
+
+  const [showCopySuccess, setShowCopySuccess] = React.useState(false)
+
+  const handleCopyRoomUrl = async () => {
+    await navigator.clipboard.writeText(window.location.href)
+    setShowCopySuccess(true)
+    setTimeout(() => {
+      setShowCopySuccess(false)
+    }, 4000)
+  }
 
   const handlePlayNext = () => {
     if (!state.playlist?.length) return
@@ -98,7 +118,17 @@ const Playlist = () => {
 
   return (
     <Section className={styles['playlist-container']}>
-      <Heading style={{ marginBottom: '1rem' }}>Now playing</Heading>
+      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+        <Heading style={{ marginBottom: '1rem' }}>Now playing</Heading>
+        <div style={{ alignSelf: 'center' }}>
+          <Button
+            renderIcon={showCopySuccess ? Checkmark : Copy}
+            onClick={handleCopyRoomUrl}
+          >
+            {showCopySuccess ? 'Copied!' : 'Copy room URL'}
+          </Button>
+        </div>
+      </div>
       <Tile style={{ display: 'flex', alignItems: 'center' }}>
         {state.player_state?.playing_url}
       </Tile>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import React, { useEffect, useState } from 'react'
-import { Content, Grid, Column, Theme } from '@carbon/react'
+import { Content, Grid, Column } from '@carbon/react'
 
 import MediaContainer from '@/app/components/MediaContainer'
 import Playlist from '@/app/components/Playlist'
+import { useStore } from './store'
 
 import styles from './page.module.sass'
 
@@ -14,16 +15,24 @@ export default function Home() {
     setMounted(true) // Ensures the component mounts after the first render
   }, [])
 
+  const store = useStore()
+
   return (
     mounted && (
       <Content className={styles['full-height']}>
         <Grid className={styles['full-height']}>
-          <Column lg={10} className={styles['full-height']}>
-            <MediaContainer />
-          </Column>
-          <Column lg={6} className={styles['full-height']}>
-            <Playlist />
-          </Column>
+          {store ? (
+            <>
+              <Column lg={10} className={styles['full-height']}>
+                <MediaContainer store={store} />
+              </Column>
+              <Column lg={6} className={styles['full-height']}>
+                <Playlist store={store} />
+              </Column>
+            </>
+          ) : (
+            'Loading...'
+          )}
         </Grid>
       </Content>
     )


### PR DESCRIPTION
This PR adds three basic capabilities to the store + webrtc provider that's already set up:
- If there is **no** room name specified in the URL already with `?room=room-name`, auto-generate a new (hopefully) unique name with https://www.npmjs.com/package/human-id and set up the webrtc provider with that room name.
- If there **is** a room name specified in the URL with `?room=room-name`, set up the webrtc provider with that room name (regardless of whether there are any other clients in that room, though that's the expected use case):
<img width="455" alt="image" src="https://github.com/jonvuri/tonlist/assets/2074135/73b39ae4-cd01-4ad4-8c19-15aca6dd2454">

- Add a 'Copy room URL' button next to Now Playing, to hint that the URL is the way to get into a room with someone:
<img width="534" alt="image" src="https://github.com/jonvuri/tonlist/assets/2074135/89df834c-56ac-41d1-b968-6d26ed4bbc73">

This also refactors the store to be initialized at the top, in the page component, to be passed down to the MediaContainer and Playlist. This serves two purposes:
1. Lets us gate on the store itself being available instead of a more arbitrary 'mounted' boolean, for initial page render.
2. Fixes next.js not actually handling client modules correctly at all. It doesn't really let us write things that depend on client APIs like document / window that are just bare code in modules, vs trapped inside some React effect hook. There does not seem to be any well-supported escape hatch for this, and I tried several different things.

I think we might be able to avoid both of these when we move away from next.js. We should revisit this when we do so, in https://github.com/jonvuri/tonlist/issues/23