### PR TITLE
Add initial, barebones Play History showing what's already played

### DIFF
--- a/app/components/PlayHistory.tsx
+++ b/app/components/PlayHistory.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import React from 'react'
+import { Heading, Section } from '@carbon/react'
+import { useSyncedStore } from '@syncedstore/react'
+
+import { Store, PlaylistEntry } from '@/app/store'
+
+import styles from './Playlist.module.sass'
+
+type PlaylistEntryRowProps = {
+  entry: PlaylistEntry
+}
+
+const PlaylistEntryRow = ({ entry }: PlaylistEntryRowProps) => {
+  return <div className={styles['playlist-entry-row']}>{entry.url}</div>
+}
+
+type Props = {
+  store: Store
+}
+
+const PlayHistory = ({ store }: Props) => {
+  const state = useSyncedStore(store)
+
+  return (
+    <Section className={styles['playlist-container']}>
+      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+        <Heading style={{ marginBottom: '1rem' }}>Play history</Heading>
+      </div>
+      <ul className={styles['playlist-next-up-container']}>
+        {state.play_history?.map((entry, index) => (
+          <li key={index}>
+            <PlaylistEntryRow entry={entry} />
+          </li>
+        ))}
+      </ul>
+    </Section>
+  )
+}
+
+export default PlayHistory

--- a/app/components/Playlist.tsx
+++ b/app/components/Playlist.tsx
@@ -14,6 +14,7 @@ import { useSyncedStore } from '@syncedstore/react'
 import { Store, PlaylistEntry } from '@/app/store'
 
 import styles from './Playlist.module.sass'
+import PlayHistory from './PlayHistory'
 
 const validUrl = (url: string) => {
   try {
@@ -111,13 +112,24 @@ const Playlist = ({ store }: Props) => {
   const handlePlayNext = () => {
     if (!state.playlist?.length) return
 
+    // Store the current entry in the play history
+    if (state.player_state.playing_url) {
+      state.play_history?.push({
+        url: state.player_state.playing_url,
+      })
+    }
+
+    // Update the player state to play the next entry in playlist
     state.player_state.playing_url = state.playlist[0].url
     state.player_state.playing_start_time = Date.now()
+
+    // Remove the next entry from the playlist
     state.playlist.splice(0, 1)
   }
 
   return (
     <Section className={styles['playlist-container']}>
+      <PlayHistory store={store} />
       <div style={{ display: 'flex', justifyContent: 'space-between' }}>
         <Heading style={{ marginBottom: '1rem' }}>Now playing</Heading>
         <div style={{ alignSelf: 'center' }}>

--- a/app/store.ts
+++ b/app/store.ts
@@ -17,6 +17,7 @@ type PlayerState = {
 type StoreShape = {
   playlist: Playlist
   player_state: PlayerState
+  play_history: Playlist
 }
 
 export type Store = ReturnType<typeof syncedStore<StoreShape>>
@@ -42,6 +43,7 @@ export const useStore = () => {
     const store = syncedStore<StoreShape>({
       playlist: [],
       player_state: {},
+      play_history: [],
     })
 
     const doc = getYjsDoc(store)


### PR DESCRIPTION
Finishes https://github.com/jonvuri/tonlist/issues/8

This PR adds a simple version of Play History that bumps the played URLs to new entries in a `play_history` on the state, and shows them similarly to the Playlist.

<img width="1118" alt="image" src="https://github.com/user-attachments/assets/7959e806-539d-4bc4-b333-64d48f55869f">
